### PR TITLE
Comment HTTP robots tag in nginx config to allow indexing by robots

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -17,7 +17,8 @@ location __PATH__/ {
 		add_header X-Content-Type-Options nosniff;
 		add_header X-Frame-Options "SAMEORIGIN";
 		add_header X-XSS-Protection "1; mode=block";
-		add_header X-Robots-Tag none;
+		# Set X-Robots-Tag to "none" if you do not want bots to index the website and follow its links
+		# add_header X-Robots-Tag all;
 		add_header X-Download-Options noopen;
 		add_header X-Permitted-Cross-Domain-Policies none;
 


### PR DESCRIPTION
Hi everyone!
I think that if you install Grav as a public app, you most likely want it to be analyzed by search engines. If it's private, it will be protected by YunoHost's SSO anyways.
Eventually, we could also consider the "noarchive" header directive to forbid people from viewing the robots' cached version of the website.

This fixes #20 by effectively resetting the robots tag to "all" 

Sorry if it's not done correctly, it's my first pull request ever :)

Ref: https://developers.google.com/search/reference/robots_meta_tag

Thanks!