### PR TITLE
Say no to all prompts during plugin update

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -163,7 +163,7 @@ find $final_path -type d -exec chmod +s {} \;
 ynh_script_progression --message="Updating all plugins..." --weight=1
 
 pushd "$final_path"
-	exec_as $app php${YNH_PHP_VERSION} bin/gpm update --all-yes --no-interaction
+	exec_as $app yes N | php${YNH_PHP_VERSION} bin/gpm update --all-yes --no-interaction
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem
- Despite `--all-yes --no-interaction`, plugins can still ask questions,
which makes upgrade hang

## Solution
- Say `N` with `yes`

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested (to test, install Git Sync in previous version and try to upgrade)
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.
