### PR TITLE
Fix linter warnings and upgrade

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
 			"email": "lithrel@randomdomainname.net"
 		}],
 	"requirements": {
-		"yunohost": ">= 4.0.7"
+		"yunohost": ">= 4.1.0"
 	},
 	"multi_instance": true,
 	"services": [

--- a/manifest.json
+++ b/manifest.json
@@ -38,38 +38,22 @@
 			{
 				"name": "domain",
 				"type": "domain",
-				"ask": {
-					"en": "Choose a domain name for Grav",
-					"fr": "Choisissez un nom de domaine pour Grav"
-				},
 				"example": "example.org"
 			},
 			{
 				"name": "path",
 				"type": "path",
-				"ask": {
-					"en": "Choose a path for Grav",
-					"fr": "Choisissez un chemin pour Grav"
-				},
 				"example": "/grav",
 				"default": "/grav"
 			},
 			{
 				"name": "admin",
 				"type": "user",
-				"ask": {
-					"en": "Choose the Grav administrator (must be an existing YunoHost user)",
-					"fr": "Administrateur du site (doit être un utilisateur YunoHost existant)"
-				},
 				"example": "johndoe"
 			},
 			{
 				"name": "is_public",
 				"type": "boolean",
-				"ask": {
-					"en": "Is it a public Grav site?",
-					"fr": "Est-ce un site public ?"
-				},
 				"help": {
 					"en": "Will anyone be able to access the website?",
 					"fr": "Est-ce que quiconque pourra accéder au site ?"
@@ -79,10 +63,6 @@
 			{
 				"name": "language",
 				"type": "string",
-				"ask": {
-					"en": "Choose the application language",
-					"fr": "Choisissez la langue de l'application"
-				},
 				"choices": ["en_EN", "fr_FR"],
 				"default": "fr_FR"
 			}

--- a/scripts/install
+++ b/scripts/install
@@ -112,11 +112,7 @@ pushd "$final_path"
 	exec_as $app touch user/accounts/admin.yaml
 popd
 
-ynh_secure_remove "$final_path/user/plugins/login-ldap/login-ldap.yaml"
-exec_as $app cp ../conf/login-ldap.yaml "$final_path/user/plugins/login-ldap/login-ldap.yaml"
-ynh_replace_string "__ADMIN__" "$admin" "$final_path/user/plugins/login-ldap/login-ldap.yaml"
-ynh_replace_string "__APP__" "$app" "$final_path/user/plugins/login-ldap/login-ldap.yaml"
-exec_as $app cp "$final_path/user/plugins/login-ldap/login-ldap.yaml" "$final_path/user/config/plugins/login-ldap.yaml"
+ynh_add_config --template="../conf/login-ldap.yaml" --destination="$final_path/user/config/plugins/login-ldap.yaml"
 
 #=================================================
 # CREATE A CRON TASK

--- a/scripts/install
+++ b/scripts/install
@@ -95,7 +95,7 @@ ynh_add_fpm_config --usage=medium --footprint=medium --package="$extra_php_depen
 #=================================================
 
 # Set permissions on app files
-chown -R $app:$app "$final_path"
+chown -R $app:www-data "$final_path"
 find "$final_path" -type f -exec chmod 640 {} \;
 find "$final_path/bin" -type f -exec chmod 750 {} \;
 find "$final_path" -type d -exec chmod 750 {} \;

--- a/scripts/install
+++ b/scripts/install
@@ -95,24 +95,24 @@ ynh_add_fpm_config --usage=medium --footprint=medium --package="$extra_php_depen
 #=================================================
 
 # Set permissions on app files
-chown -R $app:www-data $final_path
-find $final_path -type f -exec chmod 660 {} \;
-find $final_path/bin -type f -exec chmod 770 {} \;
-find $final_path -type d -exec chmod 770 {} \;
-find $final_path -type d -exec chmod +s {} \;
+chown -R $app:$app "$final_path"
+find "$final_path" -type f -exec chmod 640 {} \;
+find "$final_path/bin" -type f -exec chmod 750 {} \;
+find "$final_path" -type d -exec chmod 750 {} \;
+find "$final_path" -type d -exec chmod +s {} \;
 
 #=================================================
 # INSTALL LDAP PLUGIN
 #=================================================
 ynh_script_progression --message="Installing and configuring LDAP plugin..." --weight=1
 
-pushd "$final_path"
-	exec_as $app php${YNH_PHP_VERSION} bin/gpm install login-ldap --all-yes --no-interaction
-	exec_as $app mkdir -p user/config/plugins/login-ldap
-	exec_as $app touch user/accounts/admin.yaml
-popd
+exec_as $app php${YNH_PHP_VERSION} "$final_path/bin/gpm" install login-ldap --all-yes --no-interaction
+exec_as $app mkdir -p "$final_path/user/config/plugins/login-ldap"
+exec_as $app touch "$final_path/user/accounts/admin.yaml"
 
 ynh_add_config --template="../conf/login-ldap.yaml" --destination="$final_path/user/config/plugins/login-ldap.yaml"
+chown $app:$app "$final_path/user/config/plugins/login-ldap.yaml"
+chmod 640 "$final_path/user/config/plugins/login-ldap.yaml"
 
 #=================================================
 # CREATE A CRON TASK

--- a/scripts/install
+++ b/scripts/install
@@ -96,9 +96,9 @@ ynh_add_fpm_config --usage=medium --footprint=medium --package="$extra_php_depen
 
 # Set permissions on app files
 chown -R $app:www-data $final_path
-find $final_path -type f -exec chmod 664 {} \;
-find $final_path/bin -type f -exec chmod 775 {} \;
-find $final_path -type d -exec chmod 775 {} \;
+find $final_path -type f -exec chmod 660 {} \;
+find $final_path/bin -type f -exec chmod 770 {} \;
+find $final_path -type d -exec chmod 770 {} \;
 find $final_path -type d -exec chmod +s {} \;
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -73,7 +73,7 @@ ynh_system_user_create --username=$app --home_dir=$final_path
 #=================================================
 
 # Restore permissions on app files
-chown -R $app:$app "$final_path"
+chown -R $app:www-data "$final_path"
 find "$final_path" -type f -exec chmod 640 {} \;
 find "$final_path/bin" -type f -exec chmod 750 {} \;
 find "$final_path" -type d -exec chmod 750 {} \;

--- a/scripts/restore
+++ b/scripts/restore
@@ -73,11 +73,11 @@ ynh_system_user_create --username=$app --home_dir=$final_path
 #=================================================
 
 # Restore permissions on app files
-chown -R $app:www-data $final_path
-find $final_path -type f -exec chmod 660 {} \;
-find $final_path/bin -type f -exec chmod 770 {} \;
-find $final_path -type d -exec chmod 770 {} \;
-find $final_path -type d -exec chmod +s {} \;
+chown -R $app:$app "$final_path"
+find "$final_path" -type f -exec chmod 640 {} \;
+find "$final_path/bin" -type f -exec chmod 750 {} \;
+find "$final_path" -type d -exec chmod 750 {} \;
+find "$final_path" -type d -exec chmod +s {} \;
 
 #=================================================
 # RESTORE THE CRON

--- a/scripts/restore
+++ b/scripts/restore
@@ -74,9 +74,9 @@ ynh_system_user_create --username=$app --home_dir=$final_path
 
 # Restore permissions on app files
 chown -R $app:www-data $final_path
-find $final_path -type f -exec chmod 664 {} \;
-find $final_path/bin -type f -exec chmod 775 {} \;
-find $final_path -type d -exec chmod 775 {} \;
+find $final_path -type f -exec chmod 660 {} \;
+find $final_path/bin -type f -exec chmod 770 {} \;
+find $final_path -type d -exec chmod 770 {} \;
 find $final_path -type d -exec chmod +s {} \;
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -177,11 +177,7 @@ pushd "$final_path"
 	exec_as $app touch user/accounts/admin.yaml
 popd
 
-ynh_secure_remove "$final_path/user/plugins/login-ldap/login-ldap.yaml"
-exec_as $app cp ../conf/login-ldap.yaml "$final_path/user/plugins/login-ldap/login-ldap.yaml"
-ynh_replace_string "__ADMIN__" "$admin" "$final_path/user/plugins/login-ldap/login-ldap.yaml"
-ynh_replace_string "__APP__" "$app" "$final_path/user/plugins/login-ldap/login-ldap.yaml"
-exec_as $app cp "$final_path/user/plugins/login-ldap/login-ldap.yaml" "$final_path/user/config/plugins/login-ldap.yaml"
+ynh_add_config --template="../conf/login-ldap.yaml" --destination="$final_path/user/config/plugins/login-ldap.yaml"
 
 #=================================================
 # CREATE A CRON TASK

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -49,29 +49,9 @@ if [ -z "$final_path" ]; then
 fi
 
 # Cleaning legacy permissions
-is_public=$(ynh_app_setting_get --app=$app --key=is_public)
+if ynh_legacy_permissions_exists; then
+	ynh_legacy_permissions_delete_all
 
-if [ -n "$is_public" ]; then
-	# Removing skipped/unprotected_uris under certain conditions, remove the visitors group added during the migration process of 3.7
-	# Remove skipped_uris. If the app was public, add visitors again to the main permission
-	if ynh_permission_has_user --permission=main --user=visitors
-	then
-		# Remove unprotected_uris
-		ynh_app_setting_delete --app=$app --key=unprotected_uris
-		# Remove protected_uris
-		ynh_app_setting_delete --app=$app --key=protected_uris
-		# Remove skipped_uris
-		ynh_app_setting_delete --app=$app --key=skipped_uris
-		# Give visitors main permission
-		ynh_permission_update --permission "main" --add "visitors"
-	else
-		# Remove unprotected_uris
-		ynh_app_setting_delete --app=$app --key=unprotected_uris
-		# Remove protected_uris
-		ynh_app_setting_delete --app=$app --key=protected_uris
-		# Remove skipped_uris
-		ynh_app_setting_delete --app=$app --key=skipped_uris
-	fi
 	ynh_app_setting_delete --app=$app --key=is_public
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -150,9 +150,9 @@ fi
 
 # Set permissions on app files
 chown -R $app:www-data $final_path
-find $final_path -type f -exec chmod 664 {} \;
-find $final_path/bin -type f -exec chmod 775 {} \;
-find $final_path -type d -exec chmod 775 {} \;
+find $final_path -type f -exec chmod 660 {} \;
+find $final_path/bin -type f -exec chmod 770 {} \;
+find $final_path -type d -exec chmod 770 {} \;
 find $final_path -type d -exec chmod +s {} \;
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -151,7 +151,7 @@ fi
 #=================================================
 
 # Set permissions on app files
-chown -R $app:$app "$final_path"
+chown -R $app:www-data "$final_path"
 find "$final_path" -type f -exec chmod 640 {} \;
 find "$final_path/bin" -type f -exec chmod 750 {} \;
 find "$final_path" -type d -exec chmod 750 {} \;

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -145,39 +145,37 @@ if [ -f /etc/php/$YNH_PHP_VERSION/fpm/conf.d/20-$app.ini ]; then
 fi
 
 #=================================================
+# SPECIFIC UPGRADE
+#=================================================
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
 # Set permissions on app files
-chown -R $app:www-data $final_path
-find $final_path -type f -exec chmod 660 {} \;
-find $final_path/bin -type f -exec chmod 770 {} \;
-find $final_path -type d -exec chmod 770 {} \;
-find $final_path -type d -exec chmod +s {} \;
+chown -R $app:$app "$final_path"
+find "$final_path" -type f -exec chmod 640 {} \;
+find "$final_path/bin" -type f -exec chmod 750 {} \;
+find "$final_path" -type d -exec chmod 750 {} \;
+find "$final_path" -type d -exec chmod +s {} \;
 
-#=================================================
-# SPECIFIC UPGRADE
 #=================================================
 # UPGRADE PLUGINS
 #=================================================
 ynh_script_progression --message="Updating all plugins..." --weight=1
 
-pushd "$final_path"
-	exec_as $app yes N | exec_as $app php${YNH_PHP_VERSION} bin/gpm update --all-yes --no-interaction
-popd
+yes N | ynh_exec_warn_less exec_as $app php${YNH_PHP_VERSION} $final_path/bin/gpm update --all-yes --no-interaction
 
 #=================================================
 # INSTALL LDAP PLUGIN
 #=================================================
 ynh_script_progression --message="Installing and configuring LDAP plugin..." --weight=3
 
-pushd "$final_path"
-	exec_as $app php${YNH_PHP_VERSION} bin/gpm install login-ldap --all-yes --no-interaction
-	exec_as $app mkdir -p user/config/plugins/login-ldap
-	exec_as $app touch user/accounts/admin.yaml
-popd
+exec_as $app php${YNH_PHP_VERSION} "$final_path/bin/gpm" install login-ldap --all-yes --no-interaction
+exec_as $app mkdir -p "$final_path/user/config/plugins/login-ldap"
+exec_as $app touch "$final_path/user/accounts/admin.yaml"
 
 ynh_add_config --template="../conf/login-ldap.yaml" --destination="$final_path/user/config/plugins/login-ldap.yaml"
+chown $app:$app "$final_path/user/config/plugins/login-ldap.yaml"
+chmod 640 "$final_path/user/config/plugins/login-ldap.yaml"
 
 #=================================================
 # CREATE A CRON TASK


### PR DESCRIPTION
## Problem
- "Others" can read the apps' files
- Plugin upgrade fails

## Solution
- Remove all 'others' permissions in final_path
- Make sure $app user has the rights to write into its own directories

Closes #63 