### PR TITLE
Improve nginx.conf to avoid ?q= at the end of some URLs

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,10 +3,6 @@ location __PATH__/ {
 		alias __FINALPATH__/;
 		index index.php;
 
-		if (!-e $request_filename)
-		{
-			rewrite ^(.+)$ __PATH__/index.php?q=$1 last;
-		}
 		if ($scheme = http) {
 			rewrite ^ https://$server_name$request_uri? permanent;
 		}
@@ -20,8 +16,11 @@ location __PATH__/ {
 		more_set_headers "X-Download-Options: noopen";
 		more_set_headers "X-Permitted-Cross-Domain-Policies: none";
 
-		location ~ [^/]\.php(/|$) {
-			fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+		# Bug in Nginx with locations and aliases (see http://stackoverflow.com/a/35102259 )
+		try_files $uri $uri/ __PATH__/__PATH__/index.php?$query_string;
+
+		location ~ \.php$ {
+			fastcgi_split_path_info ^(.+\.php)(/.+)$;
 			fastcgi_pass unix:/var/run/php/php__PHPVERSION__-fpm-__NAME__.sock;
 			fastcgi_index index.php;
 			include fastcgi_params;


### PR DESCRIPTION
## Problem

#72 

## Solution

- do not use a rewrite clause
- use some sorcery due to an NGINX bug between `alias` and `try_files`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
