### PR TITLE
Implement GitHub Action to upgrade from upstream

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+#############################
+#  PACKAGE UPDATING HELPER  #
+#############################
+
+# This script is meant to be run by GitHub actions: check .github/workflows/updater.yml
+# Since each app is different, maintainers can adapt its contents
+# so as to perform automatic actions when a new upstream release is detected.
+
+# The ASSETS environment variable is a space-separated list of urls
+# of assets published with the latest upstream release.
+# Let's convert it into an array.
+eval "ASSETS=($ASSETS)"
+echo "${#ASSETS[@]} available asset(s)"
+
+# Let's loop over the array of assets URLs
+for asset_url in ${ASSETS[@]}; do
+
+echo "Handling asset at $asset_url"
+
+# Assign the asset to a source file in conf/ directory
+# Leave $src empty to ignore the asset
+case $asset_url in
+  *"admin"*)
+    src="app"
+    ;;
+  *"update"*)
+    src="app-upgrade"
+    ;;
+  *)
+    src=""
+    ;;
+esac
+
+# If $src is not empty, let's process the asset
+if [ ! -z "$src" ]; then
+
+# Create the temporary directory
+tempdir="$(mktemp -d)"
+
+# Download sources and calculate checksum
+filename=${asset_url##*/}
+curl --silent -4 -L $asset_url -o "$tempdir/$filename"
+checksum=$(sha256sum "$tempdir/$filename" | head -c 64)
+
+# Delete temporary directory
+rm -rf $tempdir
+
+# Get extension
+if [[ $filename == *.tar.gz ]]; then
+  extension=tar.gz
+else
+  extension=${filename##*.}
+fi
+
+# Rewrite source file
+cat <<EOT > conf/$src.src
+SOURCE_URL=$asset_url
+SOURCE_SUM=$checksum
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=$extension
+SOURCE_IN_SUBDIR=true
+SOURCE_FILENAME=
+EOT
+echo "... conf/$src.src updated"
+
+else
+echo "... asset ignored"
+fi
+
+done
+echo "Done!"

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -1,0 +1,71 @@
+name: Check for new upstream releases
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 6 * * *'
+jobs:
+  updater:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if newer version is available upstream
+        id: check_version
+        run: |
+          # Fetching information
+          current_version=$(cat manifest.json | jq -j '.version|split("~")[0]')
+          repo=$(cat manifest.json | jq -j '.upstream.code|split("https://github.com/")[1]')
+          version=$(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '.[] | .tag_name' | sort -V | tail -1)
+          assets=$(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '[ .[] | select(.tag_name=="'$version'").assets[].browser_download_url ] | join(" ") | @sh' | tr -d "'")
+          # Setting up the environment variables
+          echo ::set-output name=current_version::$current_version
+          echo "Current version: $current_version"
+          echo ::set-output name=latest_version::$version
+          echo "Latest release from upstream: $version"
+          echo "VERSION=$version" >> $GITHUB_ENV
+          echo "ASSETS=$assets" >> $GITHUB_ENV
+          if ! dpkg --compare-versions "$current_version" "lt" "$version" ; then
+            echo ::set-output name=to_update::false
+            echo "::warning ::No new version available"
+          elif git ls-remote -q --exit-code --heads https://github.com/$GITHUB_REPOSITORY.git ci-auto-update-v$version ; then
+            echo ::set-output name=to_update::false
+            echo "::warning ::A branch already exists for that"
+          else
+            echo ::set-output name=to_update::true
+          fi
+      - name: Update package files
+        id: update_files
+        if: steps.check_version.outputs.to_update == 'true'
+        run: |
+          # Setting up Git user
+          git config --global user.name 'yunohost-bot'
+          git config --global user.email 'yunohost-bot@users.noreply.github.com'
+          # Run the version updater script
+          ./.github/workflows/updater.sh
+          # Replace new version in manifest
+          sed -i "s#    \"version\": \".*#    \"version\": \"${VERSION}\~ynh1\",#" manifest.json
+          # Commit
+          git commit -am "Upgrade to v$VERSION"
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        if: steps.check_version.outputs.to_update == 'true'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update to version ${{ env.VERSION }}
+          committer: 'yunohost-bot <yunohost-bot@users.noreply.github.com>'
+          author: 'yunohost-bot <yunohost-bot@users.noreply.github.com>'
+          signoff: false
+          branch: ci-auto-update-v${{ env.VERSION }}
+          delete-branch: true
+          title: 'Upgrade to version ${{ env.VERSION }}'
+          body: |
+            Upgrade to v${{ env.VERSION }}
+          draft: false
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          echo "Current version - ${{ steps.check_version.outputs.current_version }}"
+          echo "New version - ${{ steps.check_version.outputs.latest_version }}"


### PR DESCRIPTION
## Problem

- Maintainer is lazy, and wants to have automated PRs to upgrade when upstream has a new release.

## Solution

- Use GitHub Actions with a cron job to check daily for new releases.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
