### PR TITLE
Fix plugin upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -177,7 +177,7 @@ find "$final_path" -type d -exec chmod +s {} \;
 ynh_script_progression --message="Updating all plugins..." --weight=1
 
 pushd "$final_path"
-	ynh_exec_warn_less yes N | ynh_exec_warn_less exec_as $app php${YNH_PHP_VERSION} bin/gpm update --all-yes --no-interaction || ynh_print_warn --message="Automatic plugin upgrade has failed, you can upgrade them from your Grav admin panel."
+	ynh_exec_warn_less yes N | ynh_exec_warn_less ynh_exec_as $app php${YNH_PHP_VERSION} bin/gpm update --all-yes --no-interaction || ynh_print_warn --message="Automatic plugin upgrade has failed, you can upgrade them from your Grav admin panel."
 popd
 
 #=================================================


### PR DESCRIPTION
## Problem

Plugin upgrade fails because the helper is not properly named.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
