### PR TITLE
Update nginx.conf

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -29,6 +29,12 @@ location __PATH__/ {
 	fastcgi_param SCRIPT_FILENAME $request_filename;
   }
 
+  ## voir https://learn.getgrav.org/17/webservers-hosting/servers/nginx#nginx-cache-headers-for-assets
+  # https://github.com/getgrav/grav-plugin-form/issues/577	
+  location ~* ^/forms-basic-captcha-image.jpg$ {
+                try_files $uri $uri/ //index.php$query_string;
+  }	
+
   location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
 	expires 30d;
 	more_set_headers "Vary: Accept-Encoding";

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -32,7 +32,7 @@ location __PATH__/ {
   ## voir https://learn.getgrav.org/17/webservers-hosting/servers/nginx#nginx-cache-headers-for-assets
   # https://github.com/getgrav/grav-plugin-form/issues/577	
   location ~* ^/forms-basic-captcha-image.jpg$ {
-                try_files $uri $uri/ //index.php$query_string;
+                 try_files $uri $uri/ __PATH__/__PATH__/index.php?$query_string;
   }	
 
   location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {


### PR DESCRIPTION
permit use  captcha addon for forms contact on grav

## Problem

- *can't use captcha protection on form contact*

## Solution

- *this line in nginx conf resolve this issue*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
