### PR TITLE
Add PHP version to admin panel upgrade commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Modern open source flat-file CMS
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.getgrav.org/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://getgrav.org/downloads/themes)
-[![Version: 2.0.12~ynh2](https://img.shields.io/badge/Version-2.0.12~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/grav/)
+[![Version: 2.0.13~ynh1](https://img.shields.io/badge/Version-2.0.13~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/grav/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/grav"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,11 +1,11 @@
-* You can access the administration panel at `__DOMAIN____PATH__/admin`. Users created within YunoHost can log in, provided their were given the appropriate permissions:
+* You can access the administration panel at `https://__DOMAIN____PATH__admin`. Users created within YunoHost can log in, provided their were given the appropriate permissions:
   * To make users administrators, give them the `grav.admin` permission.
   * To allow users to log in, without extended rights, give them the `grav.user` permission.
 * Grav offers an SSH or SFTP access, which can be enabled in its YunoHost admin configuration panel.
   * You can thus use its GPM command line binary.
     Refer to is documentation, but bear in mind you need to call it by specifying the PHP version used by the app:
-      1. `cd __INSTALL_DIR__`
-      2. `sudo -u __APP__ php__PHPVERSION__ bin/grav ...` or `sudo -u __APP__ php__PHPVERSION__bin/gpm ...`
+      1. `yunohost app shell __APP__`
+      2. `php bin/grav ...` or `php bin/gpm ...`
 * You can install plugins through the admin panel, or through the GPM.
 * If installing Grav at the root of a domain, bear in mind that paths starting by `/yunohost` are reserved.
 * Grav's automated daily self-backups are disabled by default

--- a/doc/ADMIN_fr.md
+++ b/doc/ADMIN_fr.md
@@ -1,11 +1,11 @@
-* Vous pouvez accéder au panneau d'adminstration à l'adresse `__DOMAIN____PATH__/admin`. Les utilisateurs créés dans YunoHost peuvent se connecter, à condition de leur avoir octroyé la permission adéquate:
+* Vous pouvez accéder au panneau d'adminstration à l'adresse `https://__DOMAIN____PATH__admin`. Les utilisateurs créés dans YunoHost peuvent se connecter, à condition de leur avoir octroyé la permission adéquate:
   * `grav.admin` pour qu'ils soient administrateur de Grav ;
   * `grav.user` pour qu'ils puissent se connecter, mais sans droit étendu.
 * Grav offre un accès par SSH ou SFTP, activable dans le panneau de configuration de l'application dans l'administration de YunoHost.
   * Vous pouvez ainsi utiliser sa ligne de commande GPM.
     Référez-vous à sa documentation, mais sachez que vous devrez préciser la version de PHP utilisée par l'app:
-      1. `cd __INSTALL_DIR__`
-      2. `sudo -u __APP__ php__PHPVERSION__ bin/grav ...` ou `sudo -u __APP__ php__PHPVERSION__ bin/gpm ...`
+      1. `yunohost app shell __APP__`
+      2. `php bin/grav ...` ou `php bin/gpm ...`
 * Vous pouvez installer les extensions soit via le panneau d'administration, soit via GPM.
 * Si vous installez Grav à la racine d'un domaine, sachez que les chemins d'accès commençant par `/yunohost` sont réservés.
 * Les auto-sauvegardes quotidiennes automatiques de Grav sont désactivées par défaut

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,3 +1,3 @@
 Grav has been successfully installed!
 
-You can enable or disable its SFTP access, or tweak its PHP-FPM resources profile within its configuration panel in the webadmin.
+You can enable or disable its SFTP access within its configuration panel in the webadmin.

--- a/manifest.toml
+++ b/manifest.toml
@@ -86,7 +86,10 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
-    admin.show_tile = false
+    admin.url = "/admin"
+    admin.additional_urls = ["/admin"]
+    admin.allowed = "admins"
+    admin.show_tile = true 
     user.show_tile = false
 
     [resources.apt]

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Grav"
 description.en = "Modern open source flat-file CMS"
 description.fr = "CMS moderne basé sur des fichiers plats"
 
-version = "2.0.12~ynh2"
+version = "2.0.13~ynh1"
 
 maintainers = ["tituspijean"]
 
@@ -68,14 +68,14 @@ ram.runtime = "50M"
     autoupdate.upstream = "https://github.com/trilbymedia/grav-plugin-login-ldap"
 
     [resources.sources.main]
-    url = "https://github.com/getgrav/grav/releases/download/2.0.12/grav-admin-v2.0.12.zip"
-    sha256 = "c0f3d762bfb34b0450f649d8bcbdec75446d6eb15ac459b18e7b633656506e7e"
+    url = "https://github.com/getgrav/grav/releases/download/2.0.13/grav-admin-v2.0.13.zip"
+    sha256 = "13a6ebc4c82c8603066e0d1b20f77545a0c8784a623c6d3c7ed047ec737504d5"
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset = "grav-admin.*.zip"
 
     [resources.sources.app-upgrade]
-    url = "https://github.com/getgrav/grav/releases/download/2.0.12/grav-update-v2.0.12.zip"
-    sha256 = "1f74b6e1cce20d63edf1d539349600a7e56049b0184f0e4eda09622eeb7fbf15"
+    url = "https://github.com/getgrav/grav/releases/download/2.0.13/grav-update-v2.0.13.zip"
+    sha256 = "dc10909bf992bd739fafe57f41b176df257e1403583dedc0b456248c6d151cd5"
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset = "grav-update.*.zip"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -89,7 +89,6 @@ ram.runtime = "50M"
     admin.url = "/admin"
     admin.additional_urls = ["/admin"]
     admin.allowed = "admins"
-    admin.show_tile = true 
     user.show_tile = false
 
     [resources.apt]

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -60,8 +60,8 @@ pushd "$install_dir"
 
     # Install the new admin panel for v2, remove the old one
     if ynh_app_upgrading_from_version_before 2.0.12~ynh2; then
-        ynh_exec_as_app bin/gpm install admin2 -n
-        ynh_exec_as_app bin/gpm uninstall admin -n
+        ynh_exec_as_app php${php_version} bin/gpm install admin2 -n
+        ynh_exec_as_app php${php_version} bin/gpm uninstall admin -n
     fi
 popd
 


### PR DESCRIPTION
## Problem

- *upgrade failing*

## Solution

- *provide the correct php version in install / uninstall admin plugin*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
